### PR TITLE
Update README.md to use float instead of double

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Tinn can be compiled with any C++ compiler as well.
 
     int main()
     {
-        double in[] = { 0.05, 0.10 };
-        double tg[] = { 0.01, 0.99 };
+        float in[] = { 0.05, 0.10 };
+        float tg[] = { 0.01, 0.99 };
         /* Two hidden neurons */
         const Tinn tinn = xtbuild(len(in), 2, len(tg));
         for(int i = 0; i < 1000; i++)
         {
-            double error = xttrain(tinn, in, tg, 0.5);
+            float error = xttrain(tinn, in, tg, 0.5);
             printf("%.12f\n", error);
         }
         xtfree(tinn);


### PR DESCRIPTION
The whole library uses `float` instead of `double`. I guess we should stick to it.