### PR TITLE
fix msys/mingw portability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,11 @@ else
 	MV = mv -f
 endif
 
+_SYS=$(shell uname -o)
+ifeq ($(_SYS),Msys)
+	CFLAGS += -posix	# Msys2 / Mingw64 seems to need this for printf / scanf %a support. Sigh..
+endif
+
 # Link.
 
 $(BIN): $(SRCS:.c=.o)


### PR DESCRIPTION
I noticed a compile warning (%a not supported for printf) when trying to build tinn on windows/msys2/mingw64
Also the resulting tinn.exe do not seem to compute correctly (scores are funky)
By searching a bit about the %a issue, I stumbled on this : 
https://sourceforge.net/p/mingw-w64/mailman/mingw-w64-public/thread/51AC8937.3000409@videolan.org/
And adding -posix to CFLAGS on msys systems seems to do the trick
