### PR TITLE
docs: fix simple typo, biaes -> bias

### DIFF
--- a/Tinn.c
+++ b/Tinn.c
@@ -150,7 +150,7 @@ Tinn xtload(const char* const path)
     fscanf(file, "%d %d %d\n", &nips, &nhid, &nops);
     // Build a new tinn.
     const Tinn t = xtbuild(nips, nhid, nops);
-    // Load biaes and weights.
+    // Load bias and weights.
     for(int i = 0; i < t.nb; i++) fscanf(file, "%f\n", &t.b[i]);
     for(int i = 0; i < t.nw; i++) fscanf(file, "%f\n", &t.w[i]);
     fclose(file);


### PR DESCRIPTION
There is a small typo in Tinn.c.

Should read `bias` rather than `biaes`.

