### PR TITLE
Fix - Use Fisher-Yates for uniform shuffling

### DIFF
--- a/test.c
+++ b/test.c
@@ -104,7 +104,7 @@ static void shuffle(const Data d)
 {
     for(int a = 0; a < d.rows; a++)
     {
-        const int b = rand() % d.rows;
+        const int b = a + rand() % (d.rows - a);
         float* ot = d.tg[a];
         float* it = d.in[a];
         // Swap output.


### PR DESCRIPTION
Hi @glouw first thank you very much for this elegant codebase 👍 It's truly like a piece of art to me!

However, a small issue with the shuffle algorithm: the current implementation does not produce a uniform random permutation. See [here](https://stats.stackexchange.com/questions/3082/what-is-wrong-with-this-naive-shuffling-algorithm) and [Wikipedia: Fisher–Yates shuffle](https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle) for reference.

I made a one-line change to improve with the standard Fisher-Yates algorithm, which should make the shuffling uniform. I hope this helps make the code even better. Thanks again for your great work!

### Summary

This PR updates the `shuffle` function to implement the Fisher-Yates algorithm, ensuring a uniform random shuffle of the data.

### Details

- Changed the random index calculation to select from the current index `a` to the end of the array.
- This fixes the bias in the previous shuffle implementation.
- The change is minimal, modifying only one line for correctness.

### Impact

- Ensures all permutations are equally likely.
- Improves reliability of training data shuffling in the neural network.

Please review and merge if everything looks good. Thanks!